### PR TITLE
Add cpu percentage per container

### DIFF
--- a/dockerplugin.db
+++ b/dockerplugin.db
@@ -6,4 +6,5 @@ cpu.throttling_data     periods:COUNTER:0:U, throttled_periods:COUNTER:0:U, thro
 network.usage           rx_bytes:COUNTER:0:U, rx_dropped:COUNTER:0:U, rx_errors:COUNTER:0:U, rx_packets:COUNTER:0:U, tx_bytes:COUNTER:0:U, tx_dropped:COUNTER:0:U, tx_errors:COUNTER:0:U, tx_packets:COUNTER:0:U
 memory.usage            limit:GAUGE:0:U, max:GAUGE:0:U, total:GAUGE:0:U
 memory.stats            value:GAUGE:0:U
-cpu.percent             value:GAUGE:0:150 
+memory.percent          value:GAUGE:0:150
+cpu.percent             value:GAUGE:0:150

--- a/dockerplugin.db
+++ b/dockerplugin.db
@@ -6,3 +6,4 @@ cpu.throttling_data     periods:COUNTER:0:U, throttled_periods:COUNTER:0:U, thro
 network.usage           rx_bytes:COUNTER:0:U, rx_dropped:COUNTER:0:U, rx_errors:COUNTER:0:U, rx_packets:COUNTER:0:U, tx_bytes:COUNTER:0:U, tx_dropped:COUNTER:0:U, tx_errors:COUNTER:0:U, tx_packets:COUNTER:0:U
 memory.usage            limit:GAUGE:0:U, max:GAUGE:0:U, total:GAUGE:0:U
 memory.stats            value:GAUGE:0:U
+cpu.percent             value:GAUGE:0:150 

--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -157,6 +157,9 @@ class MemoryStats(Stats):
             cls.emit(container, 'memory.stats', [value],
                      type_instance=key, t=t)
 
+        mem_percent = float(mem_stats['usage']) / float(mem_stats['limit']) * 100
+        cls.emit(container, 'memory.percent', ["%.2f" % (mem_percent)], t=t)
+
 
 class ContainerStats(threading.Thread):
     """

--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -26,7 +26,6 @@
 import dateutil.parser
 from distutils.version import StrictVersion
 import docker
-import json
 import os
 import threading
 import time
@@ -71,27 +70,28 @@ class Stats:
         val.dispatch()
 
     @classmethod
-    def read(cls, container, stats):
+    def read(cls, container, stats, t):
         raise NotImplementedError
 
 
 class BlkioStats(Stats):
     @classmethod
-    def read(cls, container, stats, extras, t):
-        for key, values in stats.items():
+    def read(cls, container, stats, t):
+        blkio_stats = stats['blkio_stats']
+        for key, values in blkio_stats.items():
             # Block IO stats are reported by block device (with major/minor
             # numbers). We need to group and report the stats of each block
             # device independently.
-            blkio_stats = {}
+            device_stats = {}
             for value in values:
                 k = '{key}-{major}-{minor}'.format(key=key,
                                                    major=value['major'],
                                                    minor=value['minor'])
-                if k not in blkio_stats:
-                    blkio_stats[k] = []
-                blkio_stats[k].append(value['value'])
+                if k not in device_stats:
+                    device_stats[k] = []
+                device_stats[k].append(value['value'])
 
-            for type_instance, values in blkio_stats.items():
+            for type_instance, values in device_stats.items():
                 if len(values) == 5:
                     cls.emit(container, 'blkio', values,
                              type_instance=type_instance, t=t)
@@ -108,47 +108,52 @@ class BlkioStats(Stats):
 
 class CpuStats(Stats):
     @classmethod
-    def read(cls, container, stats, extras, t):
-        cpu_usage = stats['cpu_usage']
-        percpu = cpu_usage['percpu_usage']
-        precpu = extras['precpu_stats']
+    def read(cls, container, stats, t):
+        cpu_stats = stats['cpu_stats']
+        cpu_usage = cpu_stats['cpu_usage']
 
+        percpu = cpu_usage['percpu_usage']
         for cpu, value in enumerate(percpu):
             cls.emit(container, 'cpu.percpu.usage', [value],
                      type_instance='cpu%d' % (cpu,), t=t)
 
-        items = sorted(stats['throttling_data'].items())
+        items = sorted(cpu_stats['throttling_data'].items())
         cls.emit(container, 'cpu.throttling_data', [x[1] for x in items], t=t)
 
+        system_cpu_usage = cpu_stats['system_cpu_usage']
         values = [cpu_usage['total_usage'], cpu_usage['usage_in_kernelmode'],
-                  cpu_usage['usage_in_usermode'], stats['system_cpu_usage']]
+                  cpu_usage['usage_in_usermode'], system_cpu_usage]
         cls.emit(container, 'cpu.usage', values, t=t)
 
-        """ CPU Percentage based on calculateCPUPercent Docker method
-            https://github.com/docker/docker/blob/master/api/client/stats.go"""
-        cpuPercent = float(0.0)
-        cpuDelta = float(cpu_usage['total_usage']) - float(precpu['cpu_usage']['total_usage'])
-        systemDelta = float(stats['system_cpu_usage']) - float(precpu['system_cpu_usage'])
-        if (systemDelta > 0.0 and cpuDelta > 0.0):
-                cpuPercent = (cpuDelta / systemDelta) * len(percpu) * 100.0
-        cls.emit(container, "cpu.percent", ["%.2f" % (cpuPercent)], t=t)
+        # CPU Percentage based on calculateCPUPercent Docker method
+        # https://github.com/docker/docker/blob/master/api/client/stats.go
+        cpu_percent = 0.0
+        if 'precpu_stats' in stats:
+            precpu_stats = stats['precpu_stats']
+            precpu_usage = precpu_stats['cpu_usage']
+            cpu_delta = float(cpu_usage['total_usage']) - float(precpu_usage['total_usage'])
+            system_delta = float(system_cpu_usage) - float(precpu_stats['system_cpu_usage'])
+            if system_delta > 0 and cpu_delta > 0:
+                cpu_percent = 100 * cpu_delta / system_delta * len(percpu)
+        cls.emit(container, "cpu.percent", ["%.2f" % (cpu_percent)], t=t)
 
 
 class NetworkStats(Stats):
     @classmethod
-    def read(cls, container, stats, extras, t):
-        items = stats.items()
-        items.sort()
+    def read(cls, container, stats, t):
+        items = sorted(stats['network'].items())
         cls.emit(container, 'network.usage', [x[1] for x in items], t=t)
 
 
 class MemoryStats(Stats):
     @classmethod
-    def read(cls, container, stats, extras, t):
-        values = [stats['limit'], stats['max_usage'], stats['usage']]
+    def read(cls, container, stats, t):
+        mem_stats = stats['memory_stats']
+        values = [mem_stats['limit'], mem_stats['max_usage'],
+                  mem_stats['usage']]
         cls.emit(container, 'memory.usage', values, t=t)
 
-        for key, value in stats['stats'].items():
+        for key, value in mem_stats['stats'].items():
             cls.emit(container, 'memory.stats', [value],
                      type_instance=key, t=t)
 
@@ -193,11 +198,9 @@ class ContainerStats(threading.Thread):
         while not self.stop:
             try:
                 if not self._feed:
-                    self._feed = self._client.stats(self._container)
-                ret = json.loads(self._feed.next())
-                # First call comes with empty precpustats we need it to be populated
-                if ret and ret['precpu_stats']['system_cpu_usage']:
-                    self._stats = ret
+                    self._feed = self._client.stats(self._container,
+                                                    decode=True)
+                self._stats = self._feed.next()
                 # Reset failure count on successfull read from the stats API.
                 failures = 0
             except Exception, e:
@@ -225,7 +228,6 @@ class ContainerStats(threading.Thread):
     def stats(self):
         """Wait, if needed, for stats to be available and return the most
         recently read stats data, parsed as JSON, for the container."""
-        """        while not self._stats or (self._stats and not self._stats['precpu_stats']['system_cpu_usage']):"""
         while not self._stats:
             pass
         return self._stats
@@ -243,12 +245,7 @@ class DockerPlugin:
     # The stats endpoint is only supported by API >= 1.17
     MIN_DOCKER_API_VERSION = '1.17'
 
-    CLASSES = {'network': NetworkStats,
-               'blkio_stats': BlkioStats,
-               'cpu_stats': CpuStats,
-               'memory_stats': MemoryStats}
-
-    EXTRA_STATS = {'cpu_stats': ['precpu_stats']}
+    CLASSES = [NetworkStats, BlkioStats, CpuStats, MemoryStats]
 
     def __init__(self, docker_url=None):
         self.docker_url = docker_url or DockerPlugin.DEFAULT_BASE_URL
@@ -302,7 +299,8 @@ class DockerPlugin:
         for container in containers:
             try:
                 for name in container['Names']:
-                    # Containers can be linked and the container name is not necessarly the first entry of the list
+                    # Containers can be linked and the container name is not
+                    # necessarly the first entry of the list
                     if not re.match("/.*/", name):
                         container['Name'] = name[1:]
 
@@ -313,17 +311,9 @@ class DockerPlugin:
 
                 # Get and process stats from the container.
                 stats = self.stats[container['Id']].stats
-                for key, value in stats.items():
-                    klass = self.CLASSES.get(key)
-                    if klass:
-                        extra = self.EXTRA_STATS.get(key)
-                        if extra:
-                            extras = {}
-                            for k in extra:
-                                extras[k] = stats[k]
-                        else:
-                            extras = None
-                        klass.read(container, value, extras, stats['read'])
+                t = stats['read']
+                for klass in self.CLASSES:
+                    klass.read(container, stats, t)
             except Exception, e:
                 collectd.warning(('Error getting stats for container '
                                   '{container}: {msg}')

--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -31,6 +31,7 @@ import os
 import threading
 import time
 import sys
+import re
 
 
 def _c(c):
@@ -76,7 +77,7 @@ class Stats:
 
 class BlkioStats(Stats):
     @classmethod
-    def read(cls, container, stats, t):
+    def read(cls, container, stats, extras, t):
         for key, values in stats.items():
             # Block IO stats are reported by block device (with major/minor
             # numbers). We need to group and report the stats of each block
@@ -107,9 +108,11 @@ class BlkioStats(Stats):
 
 class CpuStats(Stats):
     @classmethod
-    def read(cls, container, stats, t):
+    def read(cls, container, stats, extras, t):
         cpu_usage = stats['cpu_usage']
         percpu = cpu_usage['percpu_usage']
+        precpu = extras['precpu_stats']
+
         for cpu, value in enumerate(percpu):
             cls.emit(container, 'cpu.percpu.usage', [value],
                      type_instance='cpu%d' % (cpu,), t=t)
@@ -121,10 +124,19 @@ class CpuStats(Stats):
                   cpu_usage['usage_in_usermode'], stats['system_cpu_usage']]
         cls.emit(container, 'cpu.usage', values, t=t)
 
+        """ CPU Percentage based on calculateCPUPercent Docker method
+            https://github.com/docker/docker/blob/master/api/client/stats.go"""
+        cpuPercent = float(0.0)
+        cpuDelta = float(cpu_usage['total_usage']) - float(precpu['cpu_usage']['total_usage'])
+        systemDelta = float(stats['system_cpu_usage']) - float(precpu['system_cpu_usage'])
+        if (systemDelta > 0.0 and cpuDelta > 0.0):
+                cpuPercent = (cpuDelta / systemDelta) * len(percpu) * 100.0
+        cls.emit(container, "cpu.percent", ["%.2f" % (cpuPercent)], t=t)
+
 
 class NetworkStats(Stats):
     @classmethod
-    def read(cls, container, stats, t):
+    def read(cls, container, stats, extras, t):
         items = stats.items()
         items.sort()
         cls.emit(container, 'network.usage', [x[1] for x in items], t=t)
@@ -132,7 +144,7 @@ class NetworkStats(Stats):
 
 class MemoryStats(Stats):
     @classmethod
-    def read(cls, container, stats, t):
+    def read(cls, container, stats, extras, t):
         values = [stats['limit'], stats['max_usage'], stats['usage']]
         cls.emit(container, 'memory.usage', values, t=t)
 
@@ -182,8 +194,10 @@ class ContainerStats(threading.Thread):
             try:
                 if not self._feed:
                     self._feed = self._client.stats(self._container)
-                self._stats = self._feed.next()
-
+                ret = json.loads(self._feed.next())
+                # First call comes with empty precpustats we need it to be populated
+                if ret and ret['precpu_stats']['system_cpu_usage']:
+                    self._stats = ret
                 # Reset failure count on successfull read from the stats API.
                 failures = 0
             except Exception, e:
@@ -211,9 +225,10 @@ class ContainerStats(threading.Thread):
     def stats(self):
         """Wait, if needed, for stats to be available and return the most
         recently read stats data, parsed as JSON, for the container."""
+        """        while not self._stats or (self._stats and not self._stats['precpu_stats']['system_cpu_usage']):"""
         while not self._stats:
             pass
-        return json.loads(self._stats)
+        return self._stats
 
 
 class DockerPlugin:
@@ -233,6 +248,8 @@ class DockerPlugin:
                'cpu_stats': CpuStats,
                'memory_stats': MemoryStats}
 
+    EXTRA_STATS = {'cpu_stats': ['precpu_stats']}
+
     def __init__(self, docker_url=None):
         self.docker_url = docker_url or DockerPlugin.DEFAULT_BASE_URL
         self.timeout = DockerPlugin.DEFAULT_DOCKER_TIMEOUT
@@ -248,8 +265,8 @@ class DockerPlugin:
 
     def init_callback(self):
         self.client = docker.Client(
-                base_url=self.docker_url,
-                version=DockerPlugin.MIN_DOCKER_API_VERSION)
+            base_url=self.docker_url,
+            version=DockerPlugin.MIN_DOCKER_API_VERSION)
         self.client.timeout = self.timeout
 
         # Check API version for stats endpoint support.
@@ -284,7 +301,10 @@ class DockerPlugin:
 
         for container in containers:
             try:
-                container['Name'] = container['Names'][0][1:]
+                for name in container['Names']:
+                    # Containers can be linked and the container name is not necessarly the first entry of the list
+                    if not re.match("/.*/", name):
+                        container['Name'] = name[1:]
 
                 # Start a stats gathering thread if the container is new.
                 if container['Id'] not in self.stats:
@@ -296,7 +316,14 @@ class DockerPlugin:
                 for key, value in stats.items():
                     klass = self.CLASSES.get(key)
                     if klass:
-                        klass.read(container, value, stats['read'])
+                        extra = self.EXTRA_STATS.get(key)
+                        if extra:
+                            extras = {}
+                            for k in extra:
+                                extras[k] = stats[k]
+                        else:
+                            extras = None
+                        klass.read(container, value, extras, stats['read'])
             except Exception, e:
                 collectd.warning(('Error getting stats for container '
                                   '{container}: {msg}')
@@ -327,6 +354,9 @@ if __name__ == '__main__':
 
         def info(self, msg):
             print 'INFO:', msg
+
+        def register_read(self, docker_plugin):
+            pass
 
     collectd = ExecCollectd()
     plugin = DockerPlugin()


### PR DESCRIPTION
I am using collectd plugin and then export it to logstash. 

Since I am using kibana4 and it does not seem to handle derivative yet in the interface I wanted to see the cpu in a nice way.

Jiffies are nice but for a user point of view not always easy to understand, so that's why I came up with this percentage thing.

I also fixed the naming of the containers since when you link them the first entry of the list is not necessarily the container name but can be "linkedcontainer/containername". In case you restart them in different order it can create problems in your aggregation later on


I had to pass extra datas to the read method which is why I changed all the callback read, maybe not the cleanest but it works :)

Thanks for your work by the way :)

![screen shot 2015-08-07 at 9 07 29 am](https://cloud.githubusercontent.com/assets/1670389/9123449/c3f39bf0-3ce3-11e5-8c7e-8c396333b10d.png)
