### PR TITLE
Do not take time from docker stats

### DIFF
--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -55,10 +55,7 @@ class Stats:
         if type_instance:
             val.type_instance = type_instance
 
-        if t:
-            val.time = time.mktime(dateutil.parser.parse(t).timetuple())
-        else:
-            val.time = time.time()
+        val.time = time.time()
 
         # With some versions of CollectD, a dummy metadata map must to be added
         # to each value for it to be correctly serialized to JSON by the


### PR DESCRIPTION
I am using riemann ( http://riemann.io/ ) which is pretty sensible when it comes to time,  especially if you have low TTLs to see when an event expires.

I have been having quite a few alerts for that specific reason, the time read from the docker api was 60s later than the actual time synced between both servers.

I think we should just take the time from when we send the actual alerts, what do you guys think @lebauce ?