### PR TITLE
Added support for labels

### DIFF
--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -44,6 +44,10 @@ def _c(c):
         return c[:7]
     return '{id}/{name}'.format(id=c['Id'][:7], name=c['Name'])
 
+def _d(d):
+    """Formats a dictionary of key/value pairs as a comma-delimited list of
+    key=value tokens."""
+    return ','.join(['='.join(p) for p in d.items()])
 
 class Stats:
     @classmethod
@@ -51,6 +55,9 @@ class Stats:
         val = collectd.Values()
         val.plugin = 'docker'
         val.plugin_instance = container['Name']
+
+        if container['Labels']:
+            val.plugin_instance += '[{labels}]'.format(labels=_d(container['Labels']))
 
         if type:
             val.type = type


### PR DESCRIPTION
[Labels](https://docs.docker.com/engine/userguide/labels-custom-metadata/) are Docker's way of adding custom metadata to containers and images. They can be applied at image build or at runtime. They are exposed via [the Docker API](https://github.com/docker/docker-py/blob/master/docs/api.md#containers) in [the `containers` call](https://github.com/lebauce/docker-collectd-plugin/blob/master/dockerplugin.py#L307). 

This PR adds those labels to `container` as `container['Labels']`. They are then parsed and appended to the `plugin_instance` value, for example:

    :plugin_instance redis[app2.test=bob,application.test.test.test=tornado]

Given that collectd only has a 64 character limit for values this isn't ideal but is a fast way to allow us to expose a Docker container's metadata.



