### PR TITLE
Consider timezone when parsing docker's timestamp

### DIFF
--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -25,6 +25,7 @@
 
 import dateutil.parser
 from distutils.version import StrictVersion
+import calendar
 import docker
 import os
 import threading
@@ -58,7 +59,7 @@ class Stats:
             val.type_instance = type_instance
 
         if t:
-            val.time = time.mktime(dateutil.parser.parse(t).timetuple())
+            val.time = calendar.timegm(dateutil.parser.parse(t).utctimetuple())
         else:
             val.time = time.time()
 


### PR DESCRIPTION
When the plugin and the docker host is running in different timezones e.g: the
plugin runs inside a container with UTC timezone while the host is in some local
timezone, the plugin will converts the time string reported by docker into a
wrong unix timestamp.
