### PR TITLE
Safely get memory_stats.stats key

### DIFF
--- a/dockerplugin.py
+++ b/dockerplugin.py
@@ -155,7 +155,7 @@ class MemoryStats(Stats):
                   mem_stats['usage']]
         cls.emit(container, 'memory.usage', values, t=t)
 
-        for key, value in mem_stats['stats'].items():
+        for key, value in (mem_stats.get('stats') or {}).items():
             cls.emit(container, 'memory.stats', [value],
                      type_instance=key, t=t)
 


### PR DESCRIPTION
Fixes #29 by preventing NoneType error